### PR TITLE
Add domain sanitization and use constant for links

### DIFF
--- a/src/components/links/create-link.tsx
+++ b/src/components/links/create-link.tsx
@@ -36,6 +36,7 @@ import { z } from "zod";
 import CustomLinkPreview from "@/components/links/custom-link-preview";
 
 import { createLink } from "@/actions/links.actions";
+import { SHORT_LINK_DOMAIN } from "@/lib/constant";
 
 const FormSchema = z.object({
   url: z.string().url().min(1, {
@@ -153,7 +154,7 @@ export default function ShortenLink({ userDetails }: { userDetails: User }) {
                     <FormControl>
                       <div className="flex rounded-md shadow-xs">
                         <span className="border-input bg-background text-muted-foreground -z-10 inline-flex items-center rounded-s-md border px-3 text-sm">
-                          8bs.vercel.app
+                          {SHORT_LINK_DOMAIN}
                         </span>
                         <Input
                           className="-ms-px rounded-s-none shadow-none"

--- a/src/components/links/link-card.tsx
+++ b/src/components/links/link-card.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import React from "react";
 import { Button } from "../ui/button";
 import { toast } from "sonner";
+import { SHORT_LINK_DOMAIN } from "@/lib/constant";
 
 type Props = {
   link: {
@@ -35,7 +36,7 @@ export default function LinkCard({ link }: Props) {
 
   const handleCopy = () => {
     try {
-      navigator.clipboard.writeText("8bs.vercel.app/" + link.shortLink);
+      navigator.clipboard.writeText(SHORT_LINK_DOMAIN + "/" + link.shortLink);
       toast.success("Link copied to clipboard!");
       setIsCopied(true);
     } catch (error) {
@@ -57,7 +58,7 @@ export default function LinkCard({ link }: Props) {
       <div className="flex flex-1 flex-col justify-between">
         <div className="flex items-center justify-start gap-x-2">
           <h2 className="text-primary text-sm font-semibold">
-            {"8bs.vercel.app/" + link.shortLink}
+            {SHORT_LINK_DOMAIN + "/" + link.shortLink}
           </h2>
           <Button
             variant="ghost"

--- a/src/lib/constant.ts
+++ b/src/lib/constant.ts
@@ -1,0 +1,5 @@
+import { cleanDomain } from "./utils";
+
+export const SHORT_LINK_DOMAIN = cleanDomain(
+  process.env.NEXT_PUBLIC_SHORT_LINK_DOMAIN || "",
+);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,3 +8,10 @@ export function cn(...inputs: ClassValue[]) {
 export function getDomain(url: string): string {
   return (url.match(/^https?:\/\/([^\/?#]+)/)?.[1] || "").replace(/^www\./, "");
 }
+
+export function cleanDomain(domain: string): string {
+  return domain
+    .replace("https://", "")
+    .replace("http://", "")
+    .replace(/\/$/, "");
+}


### PR DESCRIPTION
Introduce a `cleanDomain` function to sanitize domain strings and replace hardcoded domain references with a new `SHORT_LINK_DOMAIN` constant in the link components.