### PR TITLE
Integrate Google Analytics and update site metadata constants

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import { Toaster } from "@/components/ui/sonner";
+import { GOOGLE_ANALYTICS_ID } from "@/lib/constant";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Silkscreen } from "next/font/google";
 import "./globals.css";
@@ -45,6 +47,7 @@ export default function RootLayout({
         {children}
         <Toaster richColors />
       </body>
+      <GoogleAnalytics gaId={GOOGLE_ANALYTICS_ID} />
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,9 @@
 import { Toaster } from "@/components/ui/sonner";
-import { GOOGLE_ANALYTICS_ID } from "@/lib/constant";
+import {
+  GOOGLE_ANALYTICS_ID,
+  GOOGLE_SITE_VERIFICATION,
+  METADATA_BASE_URL,
+} from "@/lib/constant";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Silkscreen } from "next/font/google";
@@ -27,8 +31,9 @@ export const metadata: Metadata = {
   description:
     "Manage, organize, and track your links with 8bits, the open source URL shortener and link management software built for individuals and teams.",
   verification: {
-    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+    google: GOOGLE_SITE_VERIFICATION,
   },
+  metadataBase: METADATA_BASE_URL,
   openGraph: {
     images: "/og.png",
   },

--- a/src/lib/constant.ts
+++ b/src/lib/constant.ts
@@ -3,3 +3,6 @@ import { cleanDomain } from "./utils";
 export const SHORT_LINK_DOMAIN = cleanDomain(
   process.env.NEXT_PUBLIC_SHORT_LINK_DOMAIN || "",
 );
+
+export const GOOGLE_ANALYTICS_ID =
+  process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID || "";

--- a/src/lib/constant.ts
+++ b/src/lib/constant.ts
@@ -6,3 +6,11 @@ export const SHORT_LINK_DOMAIN = cleanDomain(
 
 export const GOOGLE_ANALYTICS_ID =
   process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID || "";
+
+export const GOOGLE_SITE_VERIFICATION =
+  process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || "";
+
+export const METADATA_BASE_URL =
+  process.env.NODE_ENV === "production"
+    ? new URL("https://" + process.env.VERCEL_URL || "http://localhost:3000")
+    : new URL("http://localhost:3000");


### PR DESCRIPTION
- Add constants for Google Analytics ID, site verification, and base URL. 
- Integrate Google Analytics into the site and update metadata to utilize these constants for improved site analytics and verification.